### PR TITLE
Removed hidden layers from Color Inventory

### DIFF
--- a/Inventory/Color Inventory.sketchplugin
+++ b/Inventory/Color Inventory.sketchplugin
@@ -39,8 +39,22 @@
     // get layers
     layers = doc.currentPage().children().objectEnumerator();
 
+    var layerIsVisible = function(layer){
+      var target = layer;
+      while(target.parentGroup()){
+        if(!target.isVisible()){
+          return false;
+        }
+        target = target.parentGroup();
+      }
+      return layer.isVisible();
+    };
+
     // loop through all layers
     while (l = layers.nextObject()) {
+        if(!layerIsVisible(l)){
+            continue;
+        }
         try {
             cname = String(l.className());
             if (cname == null) continue;


### PR DESCRIPTION
Color Inventory seems to include hidden layers in the palette. To me this felt like a bug, as then I would spend time looking for the incorrect colors from screen. Therefore I made this quick hack to exclude hidden layers from the inventory.

If there's a better way to do this, I'd be happy to know. :)
